### PR TITLE
Removing json as a dependency

### DIFF
--- a/csv-data-management/requirements.txt
+++ b/csv-data-management/requirements.txt
@@ -1,4 +1,3 @@
 # Add Python Dependencies
 pandas
 numpy
-json


### PR DESCRIPTION
json is installed by default in FortiSOAR, and pip throws errors during installation because of it:
ERROR: Could not find a version that satisfies the requirement json (from -r /opt/cyops-integrations/integrations/connectors/csv-data-management_1_0_0/requirements.txt (line 4)) (from versions: none)
ERROR: No matching distribution found for json (from -r /opt/cyops-integrations/integrations/connectors/csv-data-management_1_0_0/requirements.txt (line 4))